### PR TITLE
Remove postscript (ridgepole commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,8 @@ RAILS_SERVE_STATIC_FILES=0
 
 ### 2. Deploy Containers
 ```sh
-# 1. run docker containers (if updating container required, add `--build` option)
+# run docker containers (if updating container required, add `--build` option)
 docker-compose up -d
-
-# 2. run post-deploy scripts
-# NOTE: $app_container is the web-application container name of TOJWebApp (e.g. "tojwebapp_app_1")
-
-## Check the differences of tables
-docker exec $app_container bundle exec rake ridgepole:dry-run
-
-## Create the tables in DB
-docker exec $app_container bundle exec rake ridgepole:apply
 ```
 
 TOJWebApp will be launched at `http://localhost:80` on by default. (PORT specified in `docker-compose.yml`)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tiny Programming Test Platform for Checking User's Programs
 
 ## Usage
 
-### 1. Configure Environments Variable
+### 1. Configure Environment Variables
 
 Edit `.env.sample` and save as `.env` at the root of this repository.
 
@@ -47,7 +47,7 @@ RAILS_SERVE_STATIC_FILES=0
 docker-compose up -d
 ```
 
-TOJWebApp will be launched at `http://localhost:80` on by default. (PORT specified in `docker-compose.yml`)
+TOJWebApp will be launched at `http://localhost:80` on by default. (Port can be changed in `docker-compose.yml`)
 
 ### 3. Create Users
 ```sh
@@ -66,4 +66,6 @@ docker exec -it $app_container bundle exec rake generator:students
 ```sh
 # remove all running containers (with keeping volumes)
 docker-compose down
+
+# NOTE: if completely deletion required, please remove the files in 'TOJ_DB_FILE_PATH' and 'TOJ_FILE_DIR' in your '.env' file.
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   mysql:
     container_name: $TOJ_DB_CONTAINER_NAME
@@ -25,7 +25,7 @@ services:
     links:
       - mysql:mysql
     #command: "bundle exec rails s"
-    command: "sh entrypoint.sh 3000 0.0.0.0"
+    command: "bash entrypoint.sh 3000 0.0.0.0"
     tty: true
     stdin_open: true
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,10 @@ services:
       - mysql
     links:
       - mysql:mysql
-    #command: "bundle exec rails s"
     command: "bash entrypoint.sh 3000 0.0.0.0"
     tty: true
     stdin_open: true
     ports:
-      - 80:3000
+      - 80:3000  # Port of TOJWebapp (default: 80)
     volumes:
       - $TOJ_FILE_DIR:/data
-      # - $:/workdir # ソースコード変更したらDocker側も即反映されるように

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,13 +3,46 @@
 PORT=$1
 HOST=$2
 
-# docker in docker service
+# Retries a command on failure.
+# $1 - the max number of attempts
+# $2... - the command to run
+retry() {
+    local -r -i max_attempts="$1"; shift
+    local -r cmd="$@"
+    local -i attempt_num=1
+
+    until $cmd
+    do
+        if (( attempt_num == max_attempts ))
+        then
+            echo -e "\nAttempt $attempt_num failed and there are no more attempts left!\n"
+            return 1
+        else
+            echo -e "\nAttempt $attempt_num failed! Trying again in $attempt_num seconds...\n"
+            sleep $(( attempt_num++ ))
+        fi
+    done
+}
+
+# Abort with showing error message
+# $1... - error message
+abort() {
+    echo "$@" 1>&2; exit 1
+}
+
+
+#### main ####
+
+# start docker in docker service
 wrapdocker &
-sleep 5
 
-# rails server
+
+## check differences of tables
+retry 10 "bundle exec rake ridgepole:dry-run"  || abort "failed to exec ridgepole:dry-run"
+## create tables in database
+retry 10 "bundle exec rake ridgepole:apply"  || abort "failed to exec ridgepole:apply"
+
+
+# run rails server
+echo "running rails server ..."
 bundle exec rails s -p $PORT -b $HOST
-
-while true
-    do sleep 10
-done


### PR DESCRIPTION
### 概要
デプロイ手順にある「# 2. run post-deploy scripts」の実行（下記コマンド）を自動実行し、手動でのコマンド実行を不要にする。
```sh
## Check the differences of tables
docker exec $app_container bundle exec rake ridgepole:dry-run

## Create the tables in DB
docker exec $app_container bundle exec rake ridgepole:apply
```

### 内容
- コンテナ起動後の `entry_point.sh` でRAILSサーバーを立ち上げる前に `ridgepole` のコマンドを自動実行する
- 自動実行は成功するまで複数回リトライされる
  - コンテナ起動直後はmysqlに繋がらずにコネクションエラーが発生するため自動試行が必要
  - リトライは最大10回、失敗毎に待機時間を1秒追加（試行開始から55秒経過しても成功しないならabortする）
    - マシンスペックに依存するのでもう少し長い方がいい？

### その他の修正
- `docker-compose.yml` と `README.md` の不要なコメントや英語