### PR TITLE
fix mysql version to 5.7

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:latest
+FROM mysql:5.7
 
 RUN sed -i.bak -e "s%http://archive.ubuntu.com/ubuntu/%http://ftp.jaist.ac.jp/pub/Linux/ubuntu/%g" /etc/apt/sources.list
 


### PR DESCRIPTION
mysql:latest が 8.0 とかなのだが、何か色々変わったらしくローカルで TOJ が立ち上がらなかったので 5.7 に fix した（本番環境の docker 内の mysql を確認したら 5.7.18 とかだった）