### PR TITLE
eliminate non utf-8 file

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,8 +2,15 @@ class SubmissionsController < ApplicationController
   before_action :authenticate_student!
   def create
     submission_param = params.require(:submission).permit(:code, :ta_comment, :ta_check)
-    # 2017/Apr/7 apply force_encoding
-    upload_file = submission_param[:code].read.force_encoding('utf-8')
+
+    upload_file = ''
+    unless submission_param[:code].nil? then
+      upload_file = submission_param[:code].read.force_encoding('utf-8')
+      unless upload_file.valid_encoding? then
+        upload_file = '// ++ Submitted file was not UTF-8 text. Please submit UTF-8 text file. ++'
+      end
+    end
+
     @task = Task.find(params[:task_id])
     @submission = @task.submissions.build(submission_param)
     current_student.submissions << @submission


### PR DESCRIPTION
#30 
これの原因ですが、UTF-8 として invalid な文字列が与えられたときに MySQL が壊れていたことが原因でした（Shift-JIS で日本語コメントの入ったファイルを提出しても同じエラーが出ました）。
よって、UTF-8 として invalid なファイルがきたら対処するように修正しました（invalid かどうかの判定は force_encodig('utf-8') したあと valid_encoding? をすることで行っています（これでいいのかは知らん））。
文字列を置き換えたあと普通にジャッジに回しているのはアホなのでもうちょい適切にハンドリングするべきな気はする。

#32 
これについては File が nil になってて nil に read なんてメソッドはないよって怒られていたのが原因でした。
よって、これもついでに同じところで nil 判定をして弾きました（実質空ファイルがコンパイルされる）。
これについてはフォームが空なときに提出するボタンを押せない、もしくは押せてもエラーが出るようにするべき（本当にそれはそう）。
