### PR TITLE
modify submissions page to show all submissions of student

### DIFF
--- a/app/controllers/manage/submissions_controller.rb
+++ b/app/controllers/manage/submissions_controller.rb
@@ -2,7 +2,8 @@ class Manage::SubmissionsController < ApplicationController
   before_action :authenticate_admin!
   def index
     @student = Student.find(params[:student_id])
-    @submissions = @student.submissions.group('task_id')
+    # @submissions = @student.submissions.group('task_id')
+    @submissions = @student.submissions
   end
 
   def show


### PR DESCRIPTION
#22 
#35 
`/manage/students/{id}/` と `/manage/students/{id}/submissions/` で表示される情報が違う（後者が間違っている）問題で、後者をその学生の全ての提出が見えるように変更することで仕様にしてしまうことを提案するプルリクです。