### PR TITLE
fix access authority to other student's submissions

### DIFF
--- a/app/controllers/manage/reports_controller.rb
+++ b/app/controllers/manage/reports_controller.rb
@@ -1,4 +1,5 @@
 class Manage::ReportsController < ApplicationController
+  before_action :authenticate_admin!
   def show
     @student = Student.find(params[:student_id])
     # @submission = Submission.find(params[:id])

--- a/app/controllers/pdf_controller.rb
+++ b/app/controllers/pdf_controller.rb
@@ -1,4 +1,5 @@
 class PdfController < ApplicationController
+  before_action :authenticate_student!
   def show
     report = Report.find(params[:report_id])
     if admin_signed_in?

--- a/app/controllers/pdf_controller.rb
+++ b/app/controllers/pdf_controller.rb
@@ -1,5 +1,4 @@
 class PdfController < ApplicationController
-  before_action :authenticate_student!
   def show
     report = Report.find(params[:report_id])
     if admin_signed_in?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -40,6 +40,9 @@ class SubmissionsController < ApplicationController
 
   def show
     @submission = Submission.find(params[:id])
+    unless @submission.student_id == current_student.id then
+      raise ActionController::RoutingError, with: :rescue_404
+    end
     @current_task = Task.find(@submission.task_id)
     @task_title = @current_task.title
     @code = @submission.code.to_s


### PR DESCRIPTION
よく考えたら当たり前なのですが、url 直打ちにより他の人の提出が見れたので、やべぇやべぇって言いながら対処をしました
他に同じように filtering すべきところありましたっけ…？