### PR TITLE
set filesize limit

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -10,6 +10,13 @@ class SubmissionsController < ApplicationController
       return
     end
 
+    file_lim = 60000
+
+    if submission_param[:code].size > file_lim then
+      redirect_to task_path(@task), alert: 'ファイルの容量が大きすぎます (%d Byte)．' % submission_param[:code].size
+      return
+    end
+
     upload_file = submission_param[:code].read.force_encoding('utf-8')
     unless upload_file.valid_encoding? then
       redirect_to task_path(@task), alert: 'ファイルの文字コードは UTF-8 で提出してください．'


### PR DESCRIPTION
大きすぎるファイルを提出すると落ちた（utf-8 でないファイルを投げた時と同じ症状）ので、ファイルサイズを見て大きすぎる場合は弾くようにしました
閾値は雑に二分探索をしたら 60000 byte はいけるけど 70000 byte はダメ、みたいな感じだったので適当に 60000 byte に設定しました