### PR TITLE
Fix testcases loading

### DIFF
--- a/app/controllers/manage/test_cases_controller.rb
+++ b/app/controllers/manage/test_cases_controller.rb
@@ -63,14 +63,19 @@ class Manage::TestCasesController < ApplicationController
 
   def load_file
     @task = Task.find(params[:task_id])
+    faileds = []
     file_path = "/data/tasks/#{@task.id}/*"
     Dir.glob(file_path).each do |file_name|
       name = File.basename(file_name)
       testcase = @task.test_cases.build(file_name: name)
       unless testcase.save
-        redirect_to manage_task_test_cases_path(@task), alert: '読み込みに失敗しました'
+        faileds << name
       end
     end
-    redirect_to manage_task_test_cases_path(@task), notice: '読み込みが完了しました'
+    if faileds.empty?
+      redirect_to manage_task_test_cases_path(@task), alert: "読み込みに失敗したケースがありました\n#{faileds}"
+    else
+      redirect_to manage_task_test_cases_path(@task), notice: '読み込みが完了しました'
+    end
   end
 end

--- a/app/controllers/manage/test_cases_controller.rb
+++ b/app/controllers/manage/test_cases_controller.rb
@@ -73,9 +73,9 @@ class Manage::TestCasesController < ApplicationController
       end
     end
     if faileds.empty?
-      redirect_to manage_task_test_cases_path(@task), alert: "読み込みに失敗したケースがありました\n#{faileds}"
-    else
       redirect_to manage_task_test_cases_path(@task), notice: '読み込みが完了しました'
+    else
+      redirect_to manage_task_test_cases_path(@task), alert: "読み込みに失敗したケースがありました\n#{faileds}"
     end
   end
 end


### PR DESCRIPTION
テストケースをロードするときにすでにテストケースが存在すると落ちる（redirect_to が複数回呼ばれているのが原因）なので修正を加えました
