### PR TITLE
fix mathjax

### DIFF
--- a/app/assets/javascripts/common.coffee
+++ b/app/assets/javascripts/common.coffee
@@ -1,6 +1,17 @@
 
 $.turbo.use 'turbolinks:render', 'turbolinks:request-start'
 
+$ ->
+  loadMathJax()
+  $(document).on 'turbolinks:load', loadMathJax
+
+loadMathJax = ->
+  window.MathJax = null
+  $.getScript "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML", ->
+    MathJax.Hub.Config
+      tex2jax: { inlineMath: [['$','$']] }
+
+
 ###
 statusReload = (el, taskId, submissionId) ->
   $.get "/tasks/#{taskId}/submissions/#{submissionId}/status.json", {}, (data) ->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <meta name="turbolinks-cache-control" content="no-cache">
 </head>
 <body>
 <div class="container">
@@ -25,8 +26,4 @@
   <%= yield %>
 </div>
 </body>
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$']] } });
-</script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </html>


### PR DESCRIPTION
#21 
turbolinks（キャッシュを使ってページ遷移時のデータ更新を最小限に抑えてページ遷移を高速化する機能？）が悪さをしていてページ遷移だと js が読み込まれない，というのが原因だったっぽい
`turbolinks mathjax` で検索して出てきたこの辺の記述を参考にした．
https://reed.github.io/turbolinks-compatibility/mathjax.html
https://github.com/reed/turbolinks-compatibility/issues/16#issuecomment-271097355
https://github.com/reed/turbolinks-compatibility/issues/16#issuecomment-513513896

最後の meta タグは加えなくてもほぼ正常に動作したのだが，ブラウザの戻る，進む機能を使ってページ遷移したときに再発火してしまい数式が二重に表示されてしまう，という現象が見られてこの meta タグを加えると解消された．ただ，その他の caching も抑制されてパフォーマンスが落ちている可能性も否定できない．
